### PR TITLE
Added try catch to enable support for running in VS Test Explorer wit…

### DIFF
--- a/src/Sitecore.LiveTesting/Applications/TestApplicationManager.cs
+++ b/src/Sitecore.LiveTesting/Applications/TestApplicationManager.cs
@@ -165,18 +165,28 @@
 
         foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
-          foreach (Type type in assembly.GetTypes())
-          {
-            if (type.Name == GlobalInitializationHandlerTypeName)
+            try
             {
-              if (globalInitializationHandlerType != null)
-              {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Only one global initialization handler with the name '{0}' is permitted per application domain.", GlobalInitializationHandlerTypeName));
-              }
+                foreach (Type type in assembly.GetTypes())
+                {
+                    if (type.Name == GlobalInitializationHandlerTypeName)
+                    {
+                        if (globalInitializationHandlerType != null)
+                        {
+                            throw new InvalidOperationException(
+                                string.Format(
+                                    CultureInfo.InvariantCulture,
+                                    "Only one global initialization handler with the name '{0}' is permitted per application domain.",
+                                    GlobalInitializationHandlerTypeName));
+                        }
 
-              globalInitializationHandlerType = type;
+                        globalInitializationHandlerType = type;
+                    }
+                }
             }
-          }
+            catch (ReflectionTypeLoadException)
+            {
+            }
         }
 
         if (globalInitializationHandlerType != null)


### PR DESCRIPTION
This minor change enables the Sitecore.LiveTesting to be able to run in VS Test Explorer with xUnit support. Seems like the xUnit test adapter in the VS Extension for xUnit has some problems and throws some exceptions when resolving the types from the assembly.