### PR TITLE
Feature/configuration enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# SpecFlowPlugin binaries
+/src/Sitecore.LiveTesting.SpecFlow.Tests/plugin

--- a/src/Sitecore.LiveTesting.Extensions/Sitecore.LiveTesting.Extensions.csproj
+++ b/src/Sitecore.LiveTesting.Extensions/Sitecore.LiveTesting.Extensions.csproj
@@ -85,7 +85,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=Release -sym</PostBuildEvent>
+    <PostBuildEvent>if $(ConfigurationName) == Release nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=$(ConfigurationName) -sym</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Sitecore.LiveTesting.Extensions/Sitecore.LiveTesting.Extensions.ncrunchproject
+++ b/src/Sitecore.LiveTesting.Extensions/Sitecore.LiveTesting.Extensions.ncrunchproject
@@ -24,4 +24,5 @@
       <RegularExpression>.*</RegularExpression>
     </RegexTestSelector>
   </IgnoredTests>
+  <HiddenWarnings>PostBuildEventDisabled</HiddenWarnings>
 </ProjectConfiguration>

--- a/src/Sitecore.LiveTesting.SpecFlow.Tests/App.config
+++ b/src/Sitecore.LiveTesting.SpecFlow.Tests/App.config
@@ -7,7 +7,7 @@
     <!-- For additional details on SpecFlow configuration options see http://go.specflow.org/doc-config -->
     <unitTestProvider name="xUnit" />
     <plugins>
-      <add name="Sitecore.LiveTesting" type="Generator" path="..\Sitecore.LiveTesting.SpecFlowPlugin\bin\Release" />
+      <add name="Sitecore.LiveTesting" type="Generator" path="plugin" />
     </plugins>
   </specFlow>
 </configuration>

--- a/src/Sitecore.LiveTesting.SpecFlow.Tests/Sitecore.LiveTesting.SpecFlow.Tests.ncrunchproject
+++ b/src/Sitecore.LiveTesting.SpecFlow.Tests/Sitecore.LiveTesting.SpecFlow.Tests.ncrunchproject
@@ -19,4 +19,5 @@
   <UseCPUArchitecture>AutoDetect</UseCPUArchitecture>
   <MSTestThreadApartmentState>STA</MSTestThreadApartmentState>
   <BuildProcessArchitecture>x86</BuildProcessArchitecture>
+  <AdditionalFilesToInclude>plugin\Sitecore.LiveTesting.dll;plugin\Sitecore.LiveTesting.SpecFlowPlugin.dll</AdditionalFilesToInclude>
 </ProjectConfiguration>

--- a/src/Sitecore.LiveTesting.SpecFlow.Tests/StepDefinitions.cs
+++ b/src/Sitecore.LiveTesting.SpecFlow.Tests/StepDefinitions.cs
@@ -64,6 +64,7 @@
     [When(@"test is about to be executed")]
     public void WhenTestIsAboutToBeExecuted()
     {
+      new InitializationHandlersFeature().DisposableInitializationHandlerInvocation();
     }
 
     /// <summary>
@@ -80,7 +81,7 @@
     [Then(@"initialization handler for the test is created")]
     public void ThenInitializationHandlerForTheTestIsCreated()
     {
-      Assert.Equal(1, InitializationHandler.InitializedCount);
+      Assert.Equal(3, InitializationHandler.InitializedCount);
     }
 
     /// <summary>
@@ -110,7 +111,7 @@
       /// The counters.
       /// </summary>
       private static readonly IDictionary<int, int> Counters = new ConcurrentDictionary<int, int>();
-      
+
       /// <summary>
       /// Initializes a new instance of the <see cref="InitializationHandler"/> class.
       /// </summary>
@@ -132,10 +133,10 @@
           }
 
           Trace.WriteLine(Thread.CurrentThread.ManagedThreadId);
-          
+
           return Counters[Thread.CurrentThread.ManagedThreadId];
         }
-        
+
         set
         {
           if (!Counters.ContainsKey(Thread.CurrentThread.ManagedThreadId))
@@ -146,7 +147,7 @@
           {
             Counters[Thread.CurrentThread.ManagedThreadId] = value;
           }
-        } 
+        }
       }
     }
 
@@ -158,12 +159,12 @@
       /// <summary>
       /// The disposed counters.
       /// </summary>
-      private static readonly IDictionary<int, int> DisposedCounters = new ConcurrentDictionary<int, int>();      
+      private static readonly IDictionary<int, int> DisposedCounters = new ConcurrentDictionary<int, int>();
 
       /// <summary>
       /// Gets or sets number of initialized instances.
       /// </summary>
-      public static int DisposedCount 
+      public static int DisposedCount
       {
         get
         {
@@ -185,7 +186,7 @@
           {
             DisposedCounters[Thread.CurrentThread.ManagedThreadId] = value;
           }
-        } 
+        }
       }
 
       /// <summary>

--- a/src/Sitecore.LiveTesting.SpecFlowPlugin/Sitecore.LiveTesting.SpecFlowPlugin.csproj
+++ b/src/Sitecore.LiveTesting.SpecFlowPlugin/Sitecore.LiveTesting.SpecFlowPlugin.csproj
@@ -79,7 +79,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=$(ConfigurationName) -sym</PostBuildEvent>
+    <PostBuildEvent>if $(ConfigurationName) == Release nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=$(ConfigurationName) -sym
+xcopy /i /s /e /y /r $(ProjectDir)bin\$(ConfigurationName) $(SolutionDir)Sitecore.LiveTesting.SpecFlow.Tests\plugin
+</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Sitecore.LiveTesting.SpecFlowPlugin/Sitecore.LiveTesting.SpecFlowPlugin.csproj
+++ b/src/Sitecore.LiveTesting.SpecFlowPlugin/Sitecore.LiveTesting.SpecFlowPlugin.csproj
@@ -79,7 +79,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=Release -sym</PostBuildEvent>
+    <PostBuildEvent>if $(ConfigurationName) == Release nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=$(ConfigurationName) -sym</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Sitecore.LiveTesting/Sitecore.LiveTesting.csproj
+++ b/src/Sitecore.LiveTesting/Sitecore.LiveTesting.csproj
@@ -88,7 +88,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=Release -sym</PostBuildEvent>
+    <PostBuildEvent>if $(ConfigurationName) == Release nuget pack $(ProjectPath) -OutputDirectory $(SolutionDir) -Prop Configuration=$(ConfigurationName) -sym</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Sitecore.LiveTesting/Sitecore.LiveTesting.ncrunchproject
+++ b/src/Sitecore.LiveTesting/Sitecore.LiveTesting.ncrunchproject
@@ -24,4 +24,5 @@
       <RegularExpression>.*</RegularExpression>
     </RegexTestSelector>
   </IgnoredTests>
+  <HiddenWarnings>PostBuildEventDisabled</HiddenWarnings>
 </ProjectConfiguration>


### PR DESCRIPTION
Hi Alexander!

Provided enhancement allows to run project in both Debug/Release
configuration modes.
The SpecFlowPlugin is copied into "plugin" folder under the SpecFlowTests project.
The NCrunch config files are updated to support such reference.
Nuget packages are build only in Release mode (condition is added).
